### PR TITLE
./configure: On OSX, if brew present, use /usr/local instead of /opt/local

### DIFF
--- a/configure
+++ b/configure
@@ -218,6 +218,11 @@ if($arch =~ /FreeBSD/) {
   $MAKE_PROGRAM = "gmake";
 }
 
+my $BREW_PROGRAM = "";
+if($arch =~ /Darwin/) {
+  $BREW_PROGRAM = `which brew`;
+}
+
 $error += check_config(
   "$MAKE_PROGRAM -v 2>&1 |grep --colour=never Make|",
   "GNU Make 3\.[0-9]+", #version 3.81
@@ -238,7 +243,7 @@ show_error_msg_and_exit_if_error($error);
 # if darwin or cygwin then could just modify this variable ? enough ?
 my $prefix_distrib = "/usr";
 
-if($arch =~ /FreeBSD/) {
+if( ($arch =~ /FreeBSD/) || (($arch =~ /Darwin/) && ($BREW_PROGRAM)) ) {
   $prefix_distrib = "/usr/local";
 }
 
@@ -258,6 +263,7 @@ if($bdb) {
         $BDB_INCLUDE="/opt/local/include/db46";
         $BDB_LIBS="/opt/local/lib/db46";
     }
+
     if($arch =~ /FreeBSD/) {
         $BDB_INCLUDE="/usr/local/include/db46";
         $BDB_LIBS="/usr/local/lib/db46";
@@ -291,8 +297,13 @@ if($mysql) {
 if($pcre) {
 
     if($arch =~ /Darwin/) {
-        $PCRE_INCLUDE="/opt/local/include";
-        $PCRE_LIBS="/opt/local/lib";
+        if ($BREW_PROGRAM) {
+            $PCRE_INCLUDE="/usr/local/include";
+            $PCRE_LIBS="/usr/local/lib";
+        } else {	
+            $PCRE_INCLUDE="/opt/local/include";
+            $PCRE_LIBS="/opt/local/lib";
+        }
     }
 
     if($arch =~ /FreeBSD/) {


### PR DESCRIPTION
A quick check for the most obvious Homebrew scenario, and corresponding path adjustment.
