### PR TITLE
Forgotten push2 -> push

### DIFF
--- a/lang_nw/parsing/lexer_nw.mll
+++ b/lang_nw/parsing/lexer_nw.mll
@@ -83,7 +83,7 @@ let rec current_mode () =
     reset();
     current_mode ()
 
-let push_mode mode = Common.push2 mode _mode_stack
+let push_mode mode = Common.push mode _mode_stack
 let pop_mode () = ignore(Common2.pop2 _mode_stack)
 
 }


### PR DESCRIPTION
To fix issue:

```
ocamlc.opt -g -thread -dtypes -w +A-4-29-6-45-41-44 -warn-error +a -bin-annot -absname   -I ../../commons -I ../../commons/ocamlextra -I ../../commons/lib-sexp -I ../../commons/lib-json -I ../../globals -I ../../h_program-lang   -c lexer_nw.ml
File "/usr/local/etc/facebook/pfff/lang_nw/parsing/lexer_nw.mll", line 86, characters 21-33:
Error: Unbound value Common.push2
Did you mean push?
make[2]: *** [lexer_nw.cmo] Error 2
make[1]: *** [rec] Error 1
make: *** [all] Error 2
```
