### PR TITLE
Fixed an issue where phar files are treated like php scripts

### DIFF
--- a/lang_php/parsing/lib_parsing_php.ml
+++ b/lang_php/parsing/lib_parsing_php.ml
@@ -65,8 +65,12 @@ let is_hhi_filename filename =
   (filename =~ ".*\\.hhi$") ||
   false
 
+let is_php_filename_phar filename =
+  (filename =~ ".*\\.phar$") ||
+  false
+
 let is_php_file filename =
-  is_php_filename filename || is_php_script filename
+  not (is_php_filename_phar filename) && (is_php_filename filename || is_php_script filename)
 
 (* 
  * In command line tools like git or mercurial, many operations works 


### PR DESCRIPTION
Added 'is_php_fileame_phar' function to check against the phar files
Reworked 'is_php_file' so it ignores phar files