### PR TITLE
Fix MacOSX install instructions

### DIFF
--- a/install_macos.txt
+++ b/install_macos.txt
@@ -2,7 +2,7 @@ Install brew, see http://brew.sh
 (or install macports http://www.macports.org/)
 
 Then
- $ brew install ocaml
+ $ brew install objective-caml camlp4
 
 For codemap and codegraph:
  install xquartz at http://xquartz.macosforge.org/landing/


### PR DESCRIPTION
Updates the MacOSX install instructions for installing brew dependencies.

Added `camlp4` as it's required when calling `make depend`. And `ocaml` is now called `objective-caml`.