### PR TITLE
Enable sgrep to match Booleans and Ints in PHP.

### DIFF
--- a/lang_php/matcher/php_vs_php.ml
+++ b/lang_php/matcher/php_vs_php.ml
@@ -80,6 +80,15 @@ let case_sensitive = ref false
 (* Helpers *)
 (*****************************************************************************)
 
+(* Relaxed matching of PHP's Boolean and Int types. Only integer 0 converts
+ * to false, all other integers evaluate to true.
+*)
+let is_bool_vs_int b i =
+  match b, i with
+  | "false", "0" -> true
+  | "true", n when n <> "0" -> true
+  | _ -> false
+
 let rec is_concat_of_strings e =
   match e with
   | A.Sc (A.C (A.String _)) -> true
@@ -1913,6 +1922,12 @@ and m_list__m_argument (xsa: A.argument A.comma_list) (xsb: B.argument B.comma_l
       )
     else failwith
       ("transformation (- or +) on '...' not allowed, rewrite your spatch")
+
+  (* iso on Boolean vs. Int *)
+  | [Left (A.Arg ((A.Id (A.XName [A.QI (A.Name (name_a, info_name))]))))],
+    [Left (B.Arg (B.Sc (B.C (B.Int ((name_b, _))))))]
+    when is_bool_vs_int name_a name_b ->
+      return ([Left (B.Arg (B.Sc (B.C (B.Int ((name_b, info_name))))))], xsb)
 
   | [Left (A.Arg ((A.Id (A.XName [A.QI (A.Name (name,info_name))]))))], bbs
     when MV.is_metavar_manyargs_name name ->

--- a/tests/php/sgrep/boolean_vs_int.php
+++ b/tests/php/sgrep/boolean_vs_int.php
@@ -1,0 +1,5 @@
+<?php
+
+curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, true);
+
+curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 1);


### PR DESCRIPTION
When using sgrep to scan for insecure code I've found it useful to let patterns match Boolean and integer conversions to Boolean, such as a common misuse of curl:
````
curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, true);
curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 1);
````

This PR specifically enables integer 0 to match false and integer non-zero to match true.

Thanks,
Mike