### PR TITLE
Support "!..." as not-a-string pattern.

### DIFF
--- a/lang_php/matcher/php_vs_php.ml
+++ b/lang_php/matcher/php_vs_php.ml
@@ -948,6 +948,13 @@ and m_expr a b =
        e
      )
 
+  (* MPS: iso when argument *isn't* a hard-coded string. *)
+  | A.Sc(A.C(A.String("!...", info_string))), e when not (is_concat_of_strings e)->
+     return (
+       A.Sc(A.C(A.String("!...", info_string))),
+       e
+     )
+
 
   | A.Id(a1), B.Id(b1) ->
     m_name a1 b1 >>= (fun (a1, b1) ->

--- a/tests/php/sgrep/string_args.php
+++ b/tests/php/sgrep/string_args.php
@@ -1,0 +1,12 @@
+<?php
+
+popen('/bin/ls', 'r');
+
+popen('/bin' . '/ls', 'r');
+
+$cmd = isset($_GET['cmd']) ? $_GET['cmd'] : '/bin/ls';
+popen($cmd, 'r');
+
+foo('abc');
+
+foo('abc' . $cmd);


### PR DESCRIPTION
When using sgrep to search for insecure PHP code, I've found it useful to be able to ignore function arguments that are hard-coded strings. For example, making an assumption that a hard-coded string argument to a function like popen() is probably(!?) okay, but an argument with variable substitution is more suspect and should receive more follow up.

Rather than put together complex patterns with metavariables, it's been easier to say, "not a string" with a pattern of "!...". That pattern is intended to echo the "..." for matching any string.

Thanks,
Mike