### PR TITLE
Codegraph/java: eges drawn for methods

### DIFF
--- a/find_source.ml
+++ b/find_source.ml
@@ -16,6 +16,8 @@ let finder lang =
   | "cmt"  -> 
     Lib_parsing_ml.find_cmt_files_of_dir_or_files
   | "java" -> 
+    Lib_parsing_java.find_source_files_of_dir_or_files 
+  | "javam" -> 
     Lib_parsing_java.find_source_files_of_dir_or_files
   | "js"  -> 
     Lib_parsing_js.find_source_files_of_dir_or_files ~include_scripts:false

--- a/lang_java/analyze/graph_code_java.ml
+++ b/lang_java/analyze/graph_code_java.ml
@@ -346,7 +346,7 @@ let op =
                   Some node_str_hd 
               | false ->       
                   let node_list = get_edges ~n:hd in
-                  (match aux ~verbose ~node_str:node_str_hd ~d:(d+1) ~list_:node_list ~get_edges:get_edges ~f:f with
+                  (match aux ~verbose ~node_str:node_str ~d:(d+1) ~list_:node_list ~get_edges:get_edges ~f:f with
                   | None -> aux ~verbose ~d:d ~node_str:node_str ~list_:tl ~get_edges:get_edges ~f:f 
                   | Some x -> Some x
                   )
@@ -1014,7 +1014,7 @@ and resolve_call env (expr_,_) =
         let node_str =  (last node_str_array) in
         let f a = join_list ~sep:"." a
                in
-        let dfs_f = ref (dfs ~verbose:true ~env  ~node:env.current  ~get_edges:(fun
+        let dfs_f = ref (dfs ~verbose:false ~env  ~node:env.current  ~get_edges:(fun
                 ~n -> G.succ n G.Use env.g) ~f:(fun node -> G.has_node
                 (node,E.Method) env.g) )
         in

--- a/lang_java/analyze/graph_code_java.mli
+++ b/lang_java/analyze/graph_code_java.mli
@@ -3,5 +3,6 @@ val build:
   ?verbose:bool -> 
   (* for builtins_java.ml, tags_java.ml *)
   ?only_defs:bool ->
+  ?method_to_method:bool ->
   Common.path -> Common.filename list ->
   Graph_code.graph

--- a/main_codegraph.ml
+++ b/main_codegraph.ml
@@ -328,6 +328,11 @@ let build_graph_code lang xs =
     | "clang2" -> Graph_code_clang.build ~verbose:!verbose root files, empty
 
     | "java" -> Graph_code_java.build ~verbose:!verbose root files, empty
+
+    | "javam" -> Graph_code_java.build  ~verbose:!verbose ~method_to_method:true
+    root files, empty  (*TODO: move method_to_method option to build, and not
+    language - this takes more time to complete than the previous case so
+    setting a flag to activate it*)
 #if FEATURE_BYTECODE
     | "bytecode" -> 
       let graph_code_java =  None 
@@ -380,6 +385,7 @@ let build_graph_code lang xs =
 let build_stdlib lang root dst =
   let files = Find_source.files_of_root ~lang root in
   match lang with
+  | "javam"
   | "java" ->
       Builtins_java.extract_from_sources ~src:root ~dst files
   | "clang" ->


### PR DESCRIPTION
Nodes created for methods, and Use edges drawn during method calls, from method it is called from to the method called. 

During search for method nodes in the graph; the full qualifier is guessed by prepending originating class (nested class handled too). If not, a dfs on the successors in the graph (Use edges).

.codegraph falied with an exception if duplicate node is created. This is handled (for java). 