### PR TITLE
Improve codegraph path handling

### DIFF
--- a/main_codegraph.ml
+++ b/main_codegraph.ml
@@ -417,8 +417,10 @@ let main_action xs =
         if x = "." 
         (* getcwd() display a realpath *)
         then List.hd (Common.cmd_to_list "pwd")
-        else failwith "go the directory you want"
-    | _ -> failwith "give just one directory" 
+        else
+          if Sys.is_directory(x)
+          then x
+    | _ -> failwith "unable to parse directory: codegraph <path/to/graph_code.marshall>"
   in
   let inits = Common2.inits_of_absolute_dir dir in
   let root =


### PR DESCRIPTION
It feels more natural to be able to pass `codegraph` a path to view the matrix without having to change directory. Also better information on failure.