### PR TITLE
Remove `-warn-error +a` in released builds.

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -45,7 +45,11 @@ OPTOBJS?= $(SRC:.ml=.cmx)
 #-44 allow shadow module identifier (TODO: fix them)
 #-48 allow eliminating optional arguments, unclear how to fix without wide
 #    changes
-WARNING_FLAGS?=-w +A-4-29-6-45-41-44-48 -warn-error +a 
+ifeq "$(wildcard $(TOP)/.git)" ""
+WARNING_FLAGS?=-w +A-4-29-6-45-41-44-48
+else
+WARNING_FLAGS?=-w +A-4-29-6-45-41-44-48 -warn-error +a
+endif
 
 OCAMLCFLAGS=-g -thread -dtypes $(WARNING_FLAGS) $(OCAMLCFLAGS_EXTRA) 
 


### PR DESCRIPTION
Don't use `-warn-error +a` in released source. If you want to be warning-clean, you should activate the flag only in debug/development mode. Here I'm proposing a simple solution that relies on GNUmake features. You might want to do it in the configure script instead.

As it is now, pfff 0.29 breaks on OCaml 4.03.0+beta1 because of this line (and the use of `String.capitalize`, which is now deprecated).