### PR TITLE
Replace use of uint32 by standard/ complient way

### DIFF
--- a/external/ocamlzip/zlibstubs.c
+++ b/external/ocamlzip/zlibstubs.c
@@ -16,6 +16,7 @@
 /* Stub code to interface with Zlib */
 
 #include <zlib.h>
+#include <stdint.h>
 
 #include <caml/mlvalues.h>
 #include <caml/alloc.h>
@@ -168,7 +169,7 @@ value camlzip_inflateEnd(value vzs)
 
 value camlzip_update_crc32(value crc, value buf, value pos, value len)
 {
-  return caml_copy_int32(crc32((uint32) Int32_val(crc), 
+  return caml_copy_int32(crc32((uint32_t) Int32_val(crc), 
                           &Byte_u(buf, Long_val(pos)),
                           Long_val(len)));
 }


### PR DESCRIPTION
This closes #142.

Uint32 semms to be platform specific :
- http://stackoverflow.com/questions/13362084/difference-between-uint32-and-uint32-t

This I'm importing stdint and using the standard uint32_t type.