### PR TITLE
Fix ocaml 4.04 compatibility

### DIFF
--- a/external/ocamlgtk/src/ml_glib.c
+++ b/external/ocamlgtk/src/ml_glib.c
@@ -162,7 +162,7 @@ static value *lookup_exn_map (GQuark domain)
 static void ml_raise_gerror_exn(GError *, value *) Noreturn;
 static void ml_raise_gerror_exn(GError *err, value *exn)
 {
-  CAMLlocal2(b, msg);
+  value b, msg;
   g_assert (err && exn);
   msg = copy_string(err->message);
   b = alloc_small (3, 0);


### PR DESCRIPTION
As mentionned in #151, there is a compatibilty issue with OCaml 4.04

I'am totally noob to ocaml and c is not my cup of tea (or an really old one) but I take this solution from hhmv (https://github.com/facebook/hhvm/commit/28eefc45ef093c0d81e62375bd7cb22eb6d4b947)

Don't know if it helps or broke everything but it compiles and sgrep works xD
